### PR TITLE
When using the router, define the "as" URL to include the base path

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -14,7 +14,7 @@ const Link = props => {
   // a "basePath" option.
   // https://github.com/zeit/next.js/issues/4998#issuecomment-464345554
   // We set the "as" parameter to fix client-side routing. This is a
-  // workaround for the  the missing "basePath" functionality:
+  // workaround for the missing "basePath" functionality:
   // https://github.com/zeit/next.js/issues/4998#issuecomment-520888814
   // @area/workaround/next-js-base-path
   return (

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,9 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { graphql } from 'react-relay'
 import { get } from 'lodash/object'
-import { useRouter } from 'next/router'
 import withAuthAndData from 'src/utils/pageWrappers/withAuthAndData'
 import Link from 'src/components/Link'
+import { goTo } from 'src/utils/navigation'
 import { authURL, exampleURL } from 'src/utils/urls'
 import logout from 'src/utils/auth/logout'
 
@@ -13,12 +13,10 @@ const Index = props => {
   const AuthUser = get(AuthUserInfo, 'AuthUser', null)
   const { moneyRaised } = app
   const { tabs, vcCurrent } = user
-  const router = useRouter()
-
   const onLogout = async () => {
     try {
       await logout()
-      router.push(authURL)
+      goTo(authURL)
     } catch (e) {
       // TODO: log error
       console.error(e) // eslint-disable-line no-console

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -1,10 +1,13 @@
 /* eslint import/prefer-default-export: 0 */
+import Router from 'next/router'
 import { isServerSide } from 'src/utils/ssr'
+import { withBasePath } from 'src/utils/urls'
 
 // Handle redirects on both the client side and server side.
 // Adapted from:
 // https://github.com/zeit/next.js/issues/649#issuecomment-426552156
 export const redirect = ({ location, ctx = null, status = 302 }) => {
+  const locationWithBasePath = withBasePath(location)
   if (!location) {
     throw new Error(
       'The `redirect` function must include a "location" argument.'
@@ -17,12 +20,27 @@ export const redirect = ({ location, ctx = null, status = 302 }) => {
       )
     }
     ctx.res.writeHead(status, {
-      Location: location,
+      // Server-side redirects require the subpath under which we're running this app.
+      Location: locationWithBasePath,
       'Content-Type': 'text/html; charset=utf-8',
     })
     ctx.res.end()
   } else {
-    const Router = require('next/router').default // eslint-disable-line global-require
-    Router.replace(location)
+    // We set the "as" parameter as a  workaround for the missing "basePath"
+    // functionality:
+    // https://github.com/zeit/next.js/issues/4998#issuecomment-520888814
+    // @area/workaround/next-js-base-path
+    Router.replace(location, locationWithBasePath)
   }
+}
+
+// Like Router.push but handling the basePath workaround.
+export const goTo = location => {
+  const locationWithBasePath = withBasePath(location)
+
+  // We set the "as" parameter as a  workaround for the missing "basePath"
+  // functionality:
+  // https://github.com/zeit/next.js/issues/4998#issuecomment-520888814
+  // @area/workaround/next-js-base-path
+  Router.push(location, locationWithBasePath)
 }

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -32,6 +32,8 @@ export const apiLogout = withBasePath('/api/logout')
 // we add it in the Link component's "at" prop and let Now
 // rewrite the route with the base path.
 // https://github.com/zeit/next.js/issues/4998#issuecomment-520888814
+// Note: this means we must add the base path manually for any navigation
+// we do outside of the Link component.
 // @area/workaround/next-js-base-path
 export const authURL = addTrailingSlashIfNeeded('/auth')
 export const dashboardURL = '/'


### PR DESCRIPTION
This includes the Next.js in our workaround to make routing work with a base path.