### PR TITLE
Adding inlineImageLimit to next-images config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -178,6 +178,8 @@ const nextConfig = {
       },
     ],
   },
+  // Automatically inline all images under this size.
+  inlineImageLimit: 16384,
 }
 
 module.exports = withSourceMaps(withOffline(withImages(nextConfig)))


### PR DESCRIPTION
This should allow more images to be directly embedded on page, including the logo.