### PR TITLE
remove overflow

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -62,7 +62,6 @@ const useStyles = makeStyles((theme) => ({
     height: '100vh',
     width: '100vw',
     background: theme.palette.background.paper,
-    overflow: 'hidden',
   },
   OnboardingFlow: {
     display: 'flex',


### PR DESCRIPTION
@kmjennison this overFlow hidden property cuts out the 'next' button in the onboarding flow in extreme circumstances where the page is very zoomed in or the browser is very small.  I tried removing it and playing around with the other pages to see if it had a negative impact and I didn't see anything.  Do you remember if there was a particular reason for this overflow?