### PR TITLE
[TFAC-306] Try to fix expired ID token errors

### DIFF
--- a/src/utils/hooks/useData.js
+++ b/src/utils/hooks/useData.js
@@ -4,9 +4,14 @@ import { useEffect, useState } from 'react'
 import useSWR from 'swr'
 import { fetchQuery } from 'react-relay'
 import { useAuthUser } from 'next-firebase-auth'
-import { getRelayEnvironment } from 'src/utils/relayEnvironment'
+import {
+  getRelayEnvironment,
+  waitForAuthInitialized,
+} from 'src/utils/relayEnvironment'
 
 const fetcher = async (query, variables) => {
+  // Make sure the Relay environment has a valid ID token.
+  await waitForAuthInitialized()
   const environment = getRelayEnvironment()
   return fetchQuery(environment, JSON.parse(query), JSON.parse(variables))
 }

--- a/src/utils/hooks/useData.js
+++ b/src/utils/hooks/useData.js
@@ -11,16 +11,6 @@ const fetcher = async (query, variables) => {
   return fetchQuery(environment, JSON.parse(query), JSON.parse(variables))
 }
 
-const createFetcher = (AuthUser) => async (...args) => {
-  // Ensure a valid/refreshed ID token before fetching.
-  // This is a hacky "make sure it works" workaround, because the
-  // Relay environment should use an updated user, but it's possible
-  // there's a race condition between the token refreshing + the Relay
-  // environment updating and `swr` fetching data.
-  await AuthUser.getIdToken()
-  return fetcher(...args)
-}
-
 const useData = ({ getRelayQuery, initialData, ...SWROptions }) => {
   // Before fetching data, wait for the AuthUser to initialize
   // if it's not not already available.
@@ -75,7 +65,7 @@ const useData = ({ getRelayQuery, initialData, ...SWROptions }) => {
       !readyToFetch
         ? null
         : [JSON.stringify(relayQuery), JSON.stringify(relayVariables)],
-    createFetcher(AuthUser),
+    fetcher,
     {
       initialData,
       ...SWROptions,

--- a/src/utils/hooks/useData.js
+++ b/src/utils/hooks/useData.js
@@ -11,6 +11,16 @@ const fetcher = async (query, variables) => {
   return fetchQuery(environment, JSON.parse(query), JSON.parse(variables))
 }
 
+const createFetcher = (AuthUser) => async (...args) => {
+  // Ensure a valid/refreshed ID token before fetching.
+  // This is a hacky "make sure it works" workaround, because the
+  // Relay environment should use an updated user, but it's possible
+  // there's a race condition between the token refreshing + the Relay
+  // environment updating and `swr` fetching data.
+  await AuthUser.getIdToken()
+  return fetcher(...args)
+}
+
 const useData = ({ getRelayQuery, initialData, ...SWROptions }) => {
   // Before fetching data, wait for the AuthUser to initialize
   // if it's not not already available.
@@ -65,7 +75,7 @@ const useData = ({ getRelayQuery, initialData, ...SWROptions }) => {
       !readyToFetch
         ? null
         : [JSON.stringify(relayQuery), JSON.stringify(relayVariables)],
-    fetcher,
+    createFetcher(AuthUser),
     {
       initialData,
       ...SWROptions,

--- a/src/utils/pageWrappers/__tests__/withRelay.test.js
+++ b/src/utils/pageWrappers/__tests__/withRelay.test.js
@@ -184,7 +184,7 @@ describe('withRelay', () => {
     expect(newLatestArg.clientAuthInitialized).toBe(true)
   })
 
-  it('does *not* create a new Relay network when AuthUser.clientInitialized changes from false to true', async () => {
+  it('creates a new Relay network when AuthUser.clientInitialized changes from false to true', async () => {
     expect.assertions(1)
     const withRelay = require('src/utils/pageWrappers/withRelay').default
     const { useAuthUser } = require('next-firebase-auth')
@@ -208,7 +208,7 @@ describe('withRelay', () => {
     })
     const env2 = wrapper.find(ReactRelayContext.Provider).prop('value')
       .environment
-    expect(env1.getNetwork()).toEqual(env2.getNetwork())
+    expect(env1.getNetwork()).not.toEqual(env2.getNetwork())
   })
 
   it('does *not* create a new Relay store when AuthUser.clientInitialized changes', async () => {

--- a/src/utils/pageWrappers/withRelay.js
+++ b/src/utils/pageWrappers/withRelay.js
@@ -31,24 +31,15 @@ const withRelay = (ChildComponent) => {
     // Update the Relay environment when the AuthUser changes.
     const previousAuthUser = usePrevious(AuthUser)
     useEffect(() => {
-      const updateRelayEnvAsNeeded = async () => {
-        const token = await AuthUser.getIdToken()
-        const oldToken = previousAuthUser
-          ? await previousAuthUser.getIdToken()
-          : null
-        const oldId = previousAuthUser ? previousAuthUser.id : null
-
-        // If there is a change in the AuthUser's token or ID, recreate
-        // the Relay network. We don't recreate it when auth intialization
-        // state changes, because the main consequence of that is a possible
-        // change in the token.
-        const shouldRecreateNetwork =
-          AuthUser.id !== oldId || token !== oldToken
+      const updateRelayEnvAsNeeded = () => {
+        // If there is a change in AuthUser, recreate the Relay network.
+        const shouldRecreateNetwork = AuthUser !== previousAuthUser
 
         // If the AuthUser's ID changes, recreate the Relay store.
         // Don't recreate the store if the previous user ID wasn't
         // set, because we were likely just waiting for the auth
         // client to initialize.
+        const oldId = previousAuthUser ? previousAuthUser.id : null
         const shouldRecreateStore =
           !oldId && AuthUser.id ? false : AuthUser.id !== oldId
 


### PR DESCRIPTION
Rationale behind these changes: there might be a race condition between when we update the Relay network with the new authed user and when `swr` fetches data. This PR aims to explicitly make data fetching wait for an "auth initialized" Relay network. It also recreates the network any time there's a change in the AuthUser object reference.

If this doesn't resolve the problem, [this commit](https://github.com/gladly-team/tab-web/pull/186/commits/d7f7e22057fc1ead44715de826088f2fa7259dfe) takes an alternative approach of calling for the ID token before fetching (ensuring it'll update before using it).