### PR TITLE
Support custom ad sizes and dev-only ads

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -12,6 +12,7 @@
 
 NEXT_PUBLIC_ADS_ENABLED=false
 NEXT_PUBLIC_ADS_USE_MOCK_ADS=true
+NEXT_PUBLIC_GAM_DEV_ENVIRONMENT=true
 
 
 ########## Developer/Internal Features ##########

--- a/.env.preview.info
+++ b/.env.preview.info
@@ -14,6 +14,7 @@
 
 NEXT_PUBLIC_ADS_ENABLED=true
 NEXT_PUBLIC_ADS_USE_MOCK_ADS=false
+NEXT_PUBLIC_GAM_DEV_ENVIRONMENT=true
 
 ########## Developer/Internal Features ##########
 

--- a/.env.production.info 
+++ b/.env.production.info 
@@ -14,6 +14,7 @@
 
 NEXT_PUBLIC_ADS_ENABLED=true
 NEXT_PUBLIC_ADS_USE_MOCK_ADS=false
+NEXT_PUBLIC_GAM_DEV_ENVIRONMENT=false
 
 ########## Developer/Internal Features ##########
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-transition-group": "^4.4.1",
     "relay-runtime": "^10.1.2",
     "swr": "^0.4.0",
-    "tab-ads": "^1.0.3",
+    "tab-ads": "^1.1.3",
     "tab-cmp": "^0.13.0",
     "uuid": "^3.3.2"
   },

--- a/src/__mocks__/tab-ads.js
+++ b/src/__mocks__/tab-ads.js
@@ -1,0 +1,27 @@
+import React from 'react'
+
+const mockTabAds = jest.createMockFromModule('tab-ads')
+mockTabAds.AdComponent = () => <div data-test-note="mock-ad-component" />
+
+mockTabAds.getAvailableAdUnits = jest.fn(() => ({
+  leaderboard: {
+    // The long leaderboard ad.
+    adId: 'div-gpt-ad-1464385677836-0',
+    adUnitId: '/43865596/HBTL',
+    sizes: [[728, 90]],
+  },
+  rectangleAdPrimary: {
+    // The primary rectangle ad (bottom-right).
+    adId: 'div-gpt-ad-1464385742501-0',
+    adUnitId: '/43865596/HBTR',
+    sizes: [[300, 250]],
+  },
+  rectangleAdSecondary: {
+    // The second rectangle ad (right side, above the first).
+    adId: 'div-gpt-ad-1539903223131-0',
+    adUnitId: '/43865596/HBTR2',
+    sizes: [[300, 250]],
+  },
+}))
+
+module.exports = mockTabAds

--- a/src/__tests__/pages/index.test.js
+++ b/src/__tests__/pages/index.test.js
@@ -27,6 +27,7 @@ import { accountCreated, newTabView } from 'src/utils/events'
 jest.mock('uuid/v4')
 uuid.mockReturnValue('some-uuid')
 jest.mock('next-firebase-auth')
+jest.mock('tab-ads')
 jest.mock('@material-ui/icons/Settings')
 jest.mock('src/components/Link')
 jest.mock('src/utils/navigation')

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -44,7 +44,12 @@ import UpdateImpactMutation from 'src/utils/mutations/UpdateImpactMutation'
 import LogUserRevenueMutation from 'src/utils/mutations/LogUserRevenueMutation'
 import SetHasViewedIntroFlowMutation from 'src/utils/mutations/SetHasViewedIntroFlowMutation'
 import { getHostname, getCurrentURL } from 'src/utils/navigation'
-import { getAdUnits, areAdsEnabled, showMockAds } from 'src/utils/adHelpers'
+import {
+  getAdUnits,
+  areAdsEnabled,
+  showMockAds,
+  isGAMDevEnvironment,
+} from 'src/utils/adHelpers'
 import { isClientSide } from 'src/utils/ssr'
 import { accountURL, achievementsURL, surveyLink } from 'src/utils/urls'
 import {
@@ -209,9 +214,13 @@ if (isClientSide()) {
   // this file rather than waiting for component mount.
   const loadAds = () => {
     try {
+      const setGAMDevKey = isGAMDevEnvironment()
       fetchAds({
         adUnits: Object.values(getAdUnits()),
-        pageLevelKeyValues: { v4: 'true' },
+        pageLevelKeyValues: {
+          v4: 'true',
+          ...(setGAMDevKey && { dev: 'true' }),
+        },
         auctionTimeout: 1000,
         bidderTimeout: 700,
         consent: {

--- a/src/utils/__mocks__/adHelpers.js
+++ b/src/utils/__mocks__/adHelpers.js
@@ -1,2 +1,0 @@
-const mock = jest.createMockFromModule('../adHelpers')
-module.export = mock

--- a/src/utils/__tests__/adHelpers.test.js
+++ b/src/utils/__tests__/adHelpers.test.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+jest.mock('tab-ads')
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_ADS_ENABLED = true
+  process.env.NEXT_PUBLIC_ADS_USE_MOCK_ADS = false
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+  jest.resetModules()
+})
+
+describe('isGAMDevEnvironment', () => {
+  it('returns false when env var NEXT_PUBLIC_GAM_DEV_ENVIRONMENT is undefined', async () => {
+    expect.assertions(1)
+    delete process.env.NEXT_PUBLIC_GAM_DEV_ENVIRONMENT
+    const { isGAMDevEnvironment } = require('src/utils/adHelpers')
+    expect(isGAMDevEnvironment()).toBe(false)
+  })
+
+  it('returns false when env var NEXT_PUBLIC_GAM_DEV_ENVIRONMENT=false', async () => {
+    expect.assertions(1)
+    process.env.NEXT_PUBLIC_GAM_DEV_ENVIRONMENT = false
+    const { isGAMDevEnvironment } = require('src/utils/adHelpers')
+    expect(isGAMDevEnvironment()).toBe(false)
+  })
+
+  it('returns true when env var NEXT_PUBLIC_GAM_DEV_ENVIRONMENT=true', async () => {
+    expect.assertions(1)
+    process.env.NEXT_PUBLIC_GAM_DEV_ENVIRONMENT = true
+    const { isGAMDevEnvironment } = require('src/utils/adHelpers')
+    expect(isGAMDevEnvironment()).toBe(true)
+  })
+})

--- a/src/utils/__tests__/adHelpers.test.js
+++ b/src/utils/__tests__/adHelpers.test.js
@@ -1,6 +1,3 @@
-import React from 'react'
-import { shallow } from 'enzyme'
-
 jest.mock('tab-ads')
 
 beforeEach(() => {

--- a/src/utils/adHelpers.js
+++ b/src/utils/adHelpers.js
@@ -83,3 +83,11 @@ export const areAdsEnabled = () =>
  */
 export const showMockAds = () =>
   process.env.NEXT_PUBLIC_ADS_USE_MOCK_ADS === 'true'
+
+/**
+ * Return true if we want to pass a development-only key-value to our
+ * ad server.
+ * @return {Boolean}
+ */
+export const isGAMDevEnvironment = () =>
+  process.env.NEXT_PUBLIC_GAM_DEV_ENVIRONMENT === 'true'

--- a/yarn.lock
+++ b/yarn.lock
@@ -10861,10 +10861,10 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-tab-ads@^1.0.3:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/tab-ads/-/tab-ads-1.1.1.tgz#f5055ded0c5da684c61ef4f55623fd1f7e14786f"
-  integrity sha512-bRkZqFszdNggzHzTEAFjjIf92gBSE+LZC6LDrObn5WqYZgAGlaQeW7MdWpr8EKjhGZe765E52wJvfl+vgQyGOQ==
+tab-ads@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/tab-ads/-/tab-ads-1.1.3.tgz#c578dc9135752eb08e3c10e87b065d97954701a4"
+  integrity sha512-B8ciOEQI/EOGTNSST58uI+YVTwIVUFZmZfQyJcnPSqAvla6hP8jXWFVpJJIqFjPSKfqsczi3D+77DuuzUWsrQg==
   dependencies:
     lodash "^4.17.21"
 


### PR DESCRIPTION
* Update tab-ads to support custom ad sizes
* Support dev-only ads by optionally sending `dev=true` to our ad server in a non-production environment