### PR TITLE
Fix logout bug

### DIFF
--- a/src/utils/auth/__tests__/logout.test.js
+++ b/src/utils/auth/__tests__/logout.test.js
@@ -1,10 +1,11 @@
 import getMockAuthUser from 'src/utils/testHelpers/getMockAuthUser'
 import { clearAllServiceWorkerCaches } from 'src/utils/caching'
 import logger from 'src/utils/logger'
-
+import localStorageMgr from 'src/utils/localstorage-mgr'
+import { STORAGE_KEY_USERNAME } from 'src/utils/constants'
 jest.mock('src/utils/caching')
 jest.mock('src/utils/logger')
-
+jest.mock('src/utils/localstorage-mgr', () => ({ removeItem: jest.fn() }))
 afterEach(() => {
   jest.clearAllMocks()
 })
@@ -19,6 +20,16 @@ describe('logout.js', () => {
   })
 
   it('calls clearAllServiceWorkerCaches', async () => {
+    expect.assertions(1)
+    const mockAuthUser = getMockAuthUser()
+    const logout = require('src/utils/auth/logout').default
+    await logout(mockAuthUser)
+    expect(localStorageMgr.removeItem).toHaveBeenCalledWith(
+      STORAGE_KEY_USERNAME
+    )
+  })
+
+  it('calls local storage remove item', async () => {
     expect.assertions(1)
     const mockAuthUser = getMockAuthUser()
     const logout = require('src/utils/auth/logout').default

--- a/src/utils/auth/logout.js
+++ b/src/utils/auth/logout.js
@@ -1,5 +1,7 @@
 import { clearAllServiceWorkerCaches } from 'src/utils/caching'
 import logger from 'src/utils/logger'
+import localStorageMgr from 'src/utils/localstorage-mgr'
+import { STORAGE_KEY_USERNAME } from 'src/utils/constants'
 
 const logout = async (AuthUser) => {
   try {
@@ -7,6 +9,7 @@ const logout = async (AuthUser) => {
 
     // Clear the cache so it does not contain any authed content.
     await clearAllServiceWorkerCaches()
+    await localStorageMgr.removeItem(STORAGE_KEY_USERNAME)
     return true
   } catch (e) {
     logger.error(e)

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -6,3 +6,4 @@ export const INTL_CAT_DAY_END_2021_NOTIFICATION =
 // Squad Invite Constants
 export const MISSION_COMPLETE = 'mission_complete'
 export const MISSION_STARTED = 'mission_started'
+export const STORAGE_KEY_USERNAME = 'tab.user.username'


### PR DESCRIPTION
Currently If a user logs out, then creates a brand new user, the 'create username' step is skipped and the new user is broken.  I believe that it is because the sign up checks to see if the username is set.  This change fixed my e2e tests that did this process.