### PR TITLE
Improve flushing promises for Jest 27

### DIFF
--- a/src/utils/testHelpers/flushAllPromises.js
+++ b/src/utils/testHelpers/flushAllPromises.js
@@ -1,14 +1,13 @@
+/* eslint-env jest */
+
 /**
  * Flush the Promise resolution queue. See:
  * https://github.com/facebook/jest/issues/2157
  * @return {Promise<undefined>}
  */
-const flushAllPromises = async () => {
-  await new Promise((resolve) =>
-    setTimeout(() => {
-      resolve()
-    }, 0)
-  )
-}
+// See latest:
+// https://github.com/facebook/jest/issues/2157#issuecomment-897935688
+const flushAllPromises = async () =>
+  new Promise(jest.requireActual('timers').setImmediate)
 
 export default flushAllPromises


### PR DESCRIPTION
The existing implementation could cause problems in the future for tests using mock timers.