### PR TITLE
[TFAC-690] Upgrade next-firebase-auth and add login/logout error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
     "next": "^10.0.5",
-    "next-firebase-auth": "^0.13.3",
+    "next-firebase-auth": "0.14.0-alpha.1",
     "next-images": "^1.6.2",
     "next-offline": "^5.0.3",
     "next-transpile-modules": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
     "next": "^10.0.5",
-    "next-firebase-auth": "0.14.0-alpha.1",
+    "next-firebase-auth": "^0.14.0",
     "next-images": "^1.6.2",
     "next-offline": "^5.0.3",
     "next-transpile-modules": "^8.0.0",

--- a/src/utils/auth/__tests__/initAuth.test.js
+++ b/src/utils/auth/__tests__/initAuth.test.js
@@ -5,6 +5,7 @@ import getMockFetchErrorResponse from 'src/utils/testHelpers/getMockFetchErrorRe
 import { CUSTOM_HEADER_NAME } from 'src/utils/middleware/constants'
 
 jest.mock('next-firebase-auth')
+jest.mock('src/utils/logger')
 
 beforeEach(() => {
   process.env.COOKIE_SECURE_SAME_SITE_NONE = 'true'
@@ -57,7 +58,7 @@ describe('initAuth.js', () => {
     expect(config).toHaveProperty('tokenChangedHandler')
   })
 
-  it('tokenChangedHandler calls login endpoint and sets custom header', async () => {
+  test('tokenChangedHandler calls login endpoint and sets custom header', async () => {
     expect.assertions(2)
     const { init: initNFA } = require('next-firebase-auth')
     const initAuth = require('src/utils/auth/initAuth').default
@@ -76,7 +77,7 @@ describe('initAuth.js', () => {
     })
   })
 
-  it('tokenChangedHandler throws if login endpoint call fails', async () => {
+  test('tokenChangedHandler throws if login endpoint call fails', async () => {
     expect.assertions(2)
     const { init: initNFA } = require('next-firebase-auth')
     const initAuth = require('src/utils/auth/initAuth').default
@@ -89,7 +90,7 @@ describe('initAuth.js', () => {
     ).rejects.toThrow()
   })
 
-  it('tokenChangedHandler calls logout endpoint and sets custom header', async () => {
+  test('tokenChangedHandler calls logout endpoint and sets custom header', async () => {
     expect.assertions(2)
     const { init: initNFA } = require('next-firebase-auth')
     const initAuth = require('src/utils/auth/initAuth').default
@@ -107,7 +108,7 @@ describe('initAuth.js', () => {
     })
   })
 
-  it('tokenChangedHandler throws if logout endpoint call fails', async () => {
+  test('tokenChangedHandler throws if logout endpoint call fails', async () => {
     expect.assertions(2)
     const { init: initNFA } = require('next-firebase-auth')
     const initAuth = require('src/utils/auth/initAuth').default
@@ -129,5 +130,53 @@ describe('initAuth.js', () => {
       sameSite: 'none',
       secure: true,
     })
+  })
+
+  test('onLoginRequestError calls logger.error', async () => {
+    expect.assertions(1)
+    const { init: initNFA } = require('next-firebase-auth')
+    const initAuth = require('src/utils/auth/initAuth').default
+    initAuth()
+    const logger = require('src/utils/logger').default
+    const config = initNFA.mock.calls[0][0]
+    const mockErr = new Error('foo')
+    config.onLoginRequestError(mockErr)
+    expect(logger.error).toHaveBeenCalledWith(mockErr)
+  })
+
+  test('onLogoutRequestError calls logger.error', async () => {
+    expect.assertions(1)
+    const { init: initNFA } = require('next-firebase-auth')
+    const initAuth = require('src/utils/auth/initAuth').default
+    initAuth()
+    const logger = require('src/utils/logger').default
+    const config = initNFA.mock.calls[0][0]
+    const mockErr = new Error('foo')
+    config.onLogoutRequestError(mockErr)
+    expect(logger.error).toHaveBeenCalledWith(mockErr)
+  })
+
+  test('onVerifyTokenError calls logger.error', async () => {
+    expect.assertions(1)
+    const { init: initNFA } = require('next-firebase-auth')
+    const initAuth = require('src/utils/auth/initAuth').default
+    initAuth()
+    const logger = require('src/utils/logger').default
+    const config = initNFA.mock.calls[0][0]
+    const mockErr = new Error('foo')
+    config.onVerifyTokenError(mockErr)
+    expect(logger.error).toHaveBeenCalledWith(mockErr)
+  })
+
+  test('onTokenRefreshError calls logger.error', async () => {
+    expect.assertions(1)
+    const { init: initNFA } = require('next-firebase-auth')
+    const initAuth = require('src/utils/auth/initAuth').default
+    initAuth()
+    const logger = require('src/utils/logger').default
+    const config = initNFA.mock.calls[0][0]
+    const mockErr = new Error('foo')
+    config.onTokenRefreshError(mockErr)
+    expect(logger.error).toHaveBeenCalledWith(mockErr)
   })
 })

--- a/src/utils/auth/initAuth.js
+++ b/src/utils/auth/initAuth.js
@@ -2,6 +2,7 @@ import { init } from 'next-firebase-auth'
 import ensureValuesAreDefined from 'src/utils/ensureValuesAreDefined'
 import { apiLogin, apiLogout, authURL, dashboardURL } from 'src/utils/urls'
 import { CUSTOM_HEADER_NAME } from 'src/utils/middleware/constants'
+import logger from 'src/utils/logger'
 
 try {
   ensureValuesAreDefined([
@@ -88,6 +89,18 @@ const initAuth = () => {
       authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
       databaseURL: process.env.NEXT_PUBLIC_FIREBASE_DATABASE_URL,
       projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    },
+    onLoginRequestError: (err) => {
+      logger.error(err)
+    },
+    onLogoutRequestError: (err) => {
+      logger.error(err)
+    },
+    onVerifyTokenError: (err) => {
+      logger.error(err)
+    },
+    onTokenRefreshError: (err) => {
+      logger.error(err)
     },
     cookies: {
       name: 'TabAuth',

--- a/src/utils/auth/initAuth.js
+++ b/src/utils/auth/initAuth.js
@@ -36,10 +36,12 @@ const tokenChangedHandler = async (authUser) => {
     })
     if (!response.ok) {
       const responseJSON = await response.json()
-      throw new Error(
-        `Received ${
-          response.status
-        } response from login API endpoint: ${JSON.stringify(responseJSON)}`
+      logger.error(
+        new Error(
+          `Received ${
+            response.status
+          } response from login API endpoint: ${JSON.stringify(responseJSON)}`
+        )
       )
     }
   } else {
@@ -53,10 +55,12 @@ const tokenChangedHandler = async (authUser) => {
     })
     if (!response.ok) {
       const responseJSON = await response.json()
-      throw new Error(
-        `Received ${
-          response.status
-        } response from logout API endpoint: ${JSON.stringify(responseJSON)}`
+      logger.error(
+        new Error(
+          `Received ${
+            response.status
+          } response from logout API endpoint: ${JSON.stringify(responseJSON)}`
+        )
       )
     }
   }
@@ -89,12 +93,6 @@ const initAuth = () => {
       authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
       databaseURL: process.env.NEXT_PUBLIC_FIREBASE_DATABASE_URL,
       projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-    },
-    onLoginRequestError: (err) => {
-      logger.error(err)
-    },
-    onLogoutRequestError: (err) => {
-      logger.error(err)
     },
     onVerifyTokenError: (err) => {
       logger.error(err)

--- a/yarn.lock
+++ b/yarn.lock
@@ -11098,10 +11098,10 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
-next-firebase-auth@0.14.0-alpha.1:
-  version "0.14.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/next-firebase-auth/-/next-firebase-auth-0.14.0-alpha.1.tgz#84107ea713ddb686f8b5156f74f1d042fc70c020"
-  integrity sha512-wzQswBRDg5rGfuNAYjZuzcrnV0whhD6DEtAQ1YDd8kLfv5NCU3vrdVwoiVXVAvxYGufu9kycGhYuRYWBpFSS8w==
+next-firebase-auth@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/next-firebase-auth/-/next-firebase-auth-0.14.0.tgz#006b5d5d429ffd1b5d148fade8e181ba057857c6"
+  integrity sha512-+LUIouFInwYr5kcM6/7BW+CE42cttweuIfz/ezD1zff+o/iFMee3IpNPTUO9zLuv2DYj51VbjiukSpES8caJ8w==
   dependencies:
     cookies "^0.8.0"
     hoist-non-react-statics "^3.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11098,10 +11098,10 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
-next-firebase-auth@^0.13.3:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/next-firebase-auth/-/next-firebase-auth-0.13.4.tgz#66a5cde03088f69384c78d0ad0558c19c4005912"
-  integrity sha512-E0dPpIaagoUjIcaei/puQb082d3Ut+K5wIuk14qPnJP2N2GkhufxhB0INP7rGvYSy1FqQdfywnUwn37m62+ZfA==
+next-firebase-auth@0.14.0-alpha.1:
+  version "0.14.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/next-firebase-auth/-/next-firebase-auth-0.14.0-alpha.1.tgz#84107ea713ddb686f8b5156f74f1d042fc70c020"
+  integrity sha512-wzQswBRDg5rGfuNAYjZuzcrnV0whhD6DEtAQ1YDd8kLfv5NCU3vrdVwoiVXVAvxYGufu9kycGhYuRYWBpFSS8w==
   dependencies:
     cookies "^0.8.0"
     hoist-non-react-statics "^3.3.2"


### PR DESCRIPTION
This upgrade to `next-firebase-auth` will remove any thrown errors during ID token verification, likely fixing rare but persistent new tab page errors for users with old ID tokens. See:
https://github.com/gladly-team/next-firebase-auth/releases/tag/v0.14.0

This also adds error logging (rather than error throwing) to the client fetches to the login/logout endpoints.