### PR TITLE
Remove use of system env var

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -58,9 +58,6 @@ COOKIE_SECURE_SAME_SITE_NONE=false
 
 ########## URL/Path Configuration ##########
 
-# For local development only. This is set by Vercel in deploys.
-NEXT_PUBLIC_VERCEL_URL=http://localhost:3001/
-
 # Note that the base path is also hardcoded in vercel.json and
 # next.config.js.
 NEXT_PUBLIC_URLS_BASE_PATH=/newtab

--- a/.env.development
+++ b/.env.development
@@ -58,6 +58,9 @@ COOKIE_SECURE_SAME_SITE_NONE=false
 
 ########## URL/Path Configuration ##########
 
+# For local development only. This is set by Vercel in deploys.
+NEXT_PUBLIC_VERCEL_URL=http://localhost:3001/
+
 # Note that the base path is also hardcoded in vercel.json and
 # next.config.js.
 NEXT_PUBLIC_URLS_BASE_PATH=/newtab

--- a/.env.production.info 
+++ b/.env.production.info 
@@ -24,8 +24,6 @@ NEXT_PUBLIC_GAM_DEV_ENVIRONMENT=false
 
 # May need to encrypt env vars to manage space:
 # https://vercel.com/support/articles/how-do-i-workaround-vercel-s-4-kb-environment-variables-limit
-# Alternatively, it might be easiest to first remove our use of
-# system env vars.
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=tab-for-a-cause.firebaseapp.com
 NEXT_PUBLIC_FIREBASE_CLIENT_EMAIL=firebase-adminsdk-mg6w3@tab-for-a-cause.iam.gserviceaccount.com
 NEXT_PUBLIC_FIREBASE_DATABASE_URL=https://tab-for-a-cause.firebaseio.com

--- a/__test__/next.config.test.js
+++ b/__test__/next.config.test.js
@@ -6,6 +6,7 @@ jest.mock('@zeit/next-source-maps', () => () => (config) => config)
 
 beforeEach(() => {
   process.env.NEXT_PUBLIC_VERCEL_URL = 'tab-abc123-gladly-team.vercel.app'
+  process.env.NEXT_PUBLIC_URLS_BASE_PATH = '/newtab'
 })
 
 afterEach(() => {
@@ -29,7 +30,7 @@ describe('Next.js config', () => {
     expect.assertions(1)
     const config = require('../next.config')
     expect(config.workboxOpts.runtimeCaching[0].urlPattern).toEqual(
-      /tab-abc123-gladly-team.vercel.app.*|https:\/\/prod-tab2017-media.gladly.io\/.*|https:\/\/dev-tab2017-media.gladly.io\/.*|https:\/\/dev-tab2017.gladly.io\/newtab\/.*|https:\/\/tab.gladly.io\/newtab\/.*/
+      /tab-abc123-gladly-team.vercel.app\/newtab.*|https:\/\/prod-tab2017-media.gladly.io\/.*|https:\/\/dev-tab2017-media.gladly.io\/.*|https:\/\/dev-tab2017.gladly.io\/newtab\/.*|https:\/\/tab.gladly.io\/newtab\/.*/
     )
   })
 

--- a/__test__/next.config.test.js
+++ b/__test__/next.config.test.js
@@ -4,12 +4,17 @@ jest.mock('next-transpile-modules', () => () => (config) => config)
 jest.mock('@sentry/webpack-plugin')
 jest.mock('@zeit/next-source-maps', () => () => (config) => config)
 
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_VERCEL_URL = 'tab-abc123-gladly-team.vercel.app'
+})
+
 afterEach(() => {
   jest.resetModules()
 })
 
 describe('Next.js config', () => {
   it('returns an object with some expected properties', () => {
+    expect.assertions(1)
     const config = require('../next.config')
     expect(config).toMatchObject({
       trailingSlash: true,
@@ -18,5 +23,21 @@ describe('Next.js config', () => {
       headers: expect.any(Function),
       webpack: expect.any(Function),
     })
+  })
+
+  it('sets the expected service worker caching regex', () => {
+    expect.assertions(1)
+    const config = require('../next.config')
+    expect(config.workboxOpts.runtimeCaching[0].urlPattern).toEqual(
+      /tab-abc123-gladly-team.vercel.app.*|https:\/\/prod-tab2017-media.gladly.io\/.*|https:\/\/dev-tab2017-media.gladly.io\/.*|https:\/\/dev-tab2017.gladly.io\/newtab\/.*|https:\/\/tab.gladly.io\/newtab\/.*/
+    )
+  })
+
+  it('throws if the NEXT_PUBLIC_VERCEL_URL environment variable is not set', () => {
+    expect.assertions(1)
+    delete process.env.NEXT_PUBLIC_VERCEL_URL
+    expect(() => {
+      require('../next.config')
+    }).toThrow(new Error('Env var "NEXT_PUBLIC_VERCEL_URL" is required.'))
   })
 })

--- a/__test__/next.config.test.js
+++ b/__test__/next.config.test.js
@@ -1,0 +1,22 @@
+jest.mock('next-offline', () => (config) => config)
+jest.mock('next-images', () => (config) => config)
+jest.mock('next-transpile-modules', () => () => (config) => config)
+jest.mock('@sentry/webpack-plugin')
+jest.mock('@zeit/next-source-maps', () => () => (config) => config)
+
+afterEach(() => {
+  jest.resetModules()
+})
+
+describe('Next.js config', () => {
+  it('returns an object with some expected properties', () => {
+    const config = require('../next.config')
+    expect(config).toMatchObject({
+      trailingSlash: true,
+      redirects: expect.any(Function),
+      rewrites: expect.any(Function),
+      headers: expect.any(Function),
+      webpack: expect.any(Function),
+    })
+  })
+})

--- a/__test__/next.config.test.js
+++ b/__test__/next.config.test.js
@@ -5,7 +5,6 @@ jest.mock('@sentry/webpack-plugin')
 jest.mock('@zeit/next-source-maps', () => () => (config) => config)
 
 beforeEach(() => {
-  process.env.NEXT_PUBLIC_VERCEL_URL = 'tab-abc123-gladly-team.vercel.app'
   process.env.NEXT_PUBLIC_URLS_BASE_PATH = '/newtab'
 })
 
@@ -30,15 +29,15 @@ describe('Next.js config', () => {
     expect.assertions(1)
     const config = require('../next.config')
     expect(config.workboxOpts.runtimeCaching[0].urlPattern).toEqual(
-      /tab-abc123-gladly-team.vercel.app\/newtab.*|https:\/\/prod-tab2017-media.gladly.io\/.*|https:\/\/dev-tab2017-media.gladly.io\/.*|https:\/\/dev-tab2017.gladly.io\/newtab\/.*|https:\/\/tab.gladly.io\/newtab\/.*/
+      /.*-gladly-team.vercel.app\/newtab.*|https:\/\/prod-tab2017-media.gladly.io\/.*|https:\/\/dev-tab2017-media.gladly.io\/.*|https:\/\/dev-tab2017.gladly.io\/newtab\/.*|https:\/\/tab.gladly.io\/newtab\/.*/
     )
   })
 
-  it('throws if the NEXT_PUBLIC_VERCEL_URL environment variable is not set', () => {
+  it('does not throw if the NEXT_PUBLIC_VERCEL_URL environment variable is not set', () => {
     expect.assertions(1)
     delete process.env.NEXT_PUBLIC_VERCEL_URL
     expect(() => {
       require('../next.config')
-    }).toThrow(new Error('Env var "NEXT_PUBLIC_VERCEL_URL" is required.'))
+    }).not.toThrow()
   })
 })

--- a/next.config.js
+++ b/next.config.js
@@ -34,7 +34,11 @@ const withSourceMaps = require('@zeit/next-source-maps')({
 })
 
 const basePath = process.env.NEXT_PUBLIC_URLS_BASE_PATH || ''
-const url = process.env.VERCEL_URL || 'http://localhost:3001/'
+const url = process.env.NEXT_PUBLIC_VERCEL_URL
+if (!url) {
+  throw new Error('Env var "NEXT_PUBLIC_VERCEL_URL" is required.')
+}
+
 const devAssetsRegex = 'https://prod-tab2017-media.gladly.io/.*'
 const prodAssetsRegex = 'https://dev-tab2017-media.gladly.io/.*'
 const devCloudFrontRegex = 'https://dev-tab2017.gladly.io/newtab/.*'

--- a/next.config.js
+++ b/next.config.js
@@ -34,18 +34,14 @@ const withSourceMaps = require('@zeit/next-source-maps')({
 })
 
 const basePath = process.env.NEXT_PUBLIC_URLS_BASE_PATH || ''
-const url = process.env.NEXT_PUBLIC_VERCEL_URL
-if (!url) {
-  throw new Error('Env var "NEXT_PUBLIC_VERCEL_URL" is required.')
-}
-
+const generalizedVercelDomain = '.*-gladly-team.vercel.app'
 const devAssetsRegex = 'https://prod-tab2017-media.gladly.io/.*'
 const prodAssetsRegex = 'https://dev-tab2017-media.gladly.io/.*'
 const devCloudFrontRegex = 'https://dev-tab2017.gladly.io/newtab/.*'
 const prodCloudFrontRegex = 'https://tab.gladly.io/newtab/.*'
 
 const cachingRegex = new RegExp(
-  `${url}${basePath}.*|${devAssetsRegex}|${prodAssetsRegex}|${devCloudFrontRegex}|${prodCloudFrontRegex}`
+  `${generalizedVercelDomain}${basePath}.*|${devAssetsRegex}|${prodAssetsRegex}|${devCloudFrontRegex}|${prodCloudFrontRegex}`
 )
 
 // Use the SentryWebpack plugin to upload the source maps during build.


### PR DESCRIPTION
We're hitting environment variable memory limits on Vercel:
https://vercel.com/docs/concepts/limits/overview#environment-variables

This PR removes dependence on a system environment variable so that we can stop exposing system environment variables.