### PR TITLE
TFAC-1157 Showing 3rd Ad on v4

### DIFF
--- a/src/__tests__/pages/index.test.js
+++ b/src/__tests__/pages/index.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { shallow, mount } from 'enzyme'
 import Link from 'src/components/Link'
+import MockDate from 'mockdate'
 import IconButton from '@material-ui/core/IconButton'
 import SettingsIcon from '@material-ui/icons/Settings'
 import { aboutURL, accountURL } from 'src/utils/urls'
@@ -52,6 +53,7 @@ import useBrowserName from 'src/utils/hooks/useBrowserName'
 import SfacActivityContainer from 'src/components/SfacActivityContainer'
 import { isSearchActivityComponentSupported } from 'src/utils/browserSupport'
 import localStorageFeaturesManager from 'src/utils/localStorageFeaturesManager'
+import moment from 'moment'
 
 jest.mock('uuid')
 uuid.mockReturnValue('some-uuid')
@@ -176,6 +178,7 @@ const getMockCurrentMission = () => ({
   tabCount: 6,
   missionId: 'abc-123',
 })
+const mockNow = '2021-08-29T18:37:04.604Z'
 
 beforeEach(() => {
   showMockAchievements.mockReturnValue(false)
@@ -184,10 +187,12 @@ beforeEach(() => {
   process.env.NEXT_PUBLIC_SERVICE_WORKER_ENABLED = 'false'
   useDoesBrowserSupportSearchExtension.mockReturnValue(true)
   useBrowserName.mockReturnValue('chrome')
+  MockDate.set(moment(mockNow))
 })
 
 afterEach(() => {
   jest.clearAllMocks()
+  MockDate.set(moment(mockNow))
 })
 
 /* START: core tests */
@@ -917,13 +922,15 @@ describe('index.js', () => {
     useGrowthBook.mockReturnValue(mockGrowthbook)
     mount(<IndexPage {...mockProps} />)
 
+    const expectedJoinedTime = new Date(mockProps.data.user.joined).valueOf()
     const expectedAttributesObject = {
       id: mockProps.data.user.id,
       env: process.env.NEXT_PUBLIC_GROWTHBOOK_ENV,
       causeId: mockProps.data.user.cause.causeId,
       v4BetaEnabled: true,
-      joined: mockProps.data.user.joined,
+      joined: expectedJoinedTime,
       isTabTeamMember: showInternalOnly(mockProps.data.user.email),
+      timeSinceJoined: moment.utc().valueOf() - expectedJoinedTime,
     }
     expect(validateAttributesObject).toHaveBeenCalledWith(
       mockProps.data.user.id,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,6 +14,7 @@ import {
   withAuthUserTokenSSR,
   AuthAction,
 } from 'next-firebase-auth'
+import moment from 'moment'
 import { useGrowthBook } from '@growthbook/growthbook-react'
 
 // custom components
@@ -470,14 +471,17 @@ const Index = ({ data: fallbackData, userAgent }) => {
 
   // Set Growthbook attributes when the user is defined.
   useEffect(() => {
+    const joinedTime = joined && new Date(joined).getTime()
+    const timeSinceJoined = joinedTime && moment.utc().valueOf() - joinedTime
     if (userId) {
       const attributesObject = {
         id: userId,
         env: process.env.NEXT_PUBLIC_GROWTHBOOK_ENV,
         causeId,
         v4BetaEnabled: true,
-        joined,
+        joined: joinedTime,
         isTabTeamMember: showInternalOnly(email),
+        timeSinceJoined,
       }
       validateAttributesObject(userId, attributesObject)
       growthbook.setAttributes(attributesObject)

--- a/src/utils/adHelpers.js
+++ b/src/utils/adHelpers.js
@@ -2,6 +2,9 @@ import { getAvailableAdUnits } from 'tab-ads'
 import ensureValuesAreDefined from 'src/utils/ensureValuesAreDefined'
 import moment from 'moment'
 import localStorageMgr from './localstorage-mgr'
+import localStorageFeaturesManager from './localStorageFeaturesManager'
+import { V4_SHOW_THIRD_AD } from './experiments'
+
 import {
   STORAGE_TABS_RECENT_DAY_COUNT,
   STORAGE_TABS_LAST_TAB_OPENED_DATE,
@@ -133,6 +136,14 @@ export const incrementTabsOpenedToday = () => {
 const shouldShowOneAd = () => false
 
 /**
+ * Determine if we should show three ads. Controlled by V4_SHOW_THIRD_AD
+ * growthbook feature.
+ * @return {Boolean} Whether to show one ad.
+ */
+const shouldShowThreeAds = () =>
+  localStorageFeaturesManager.getFeatureValue(V4_SHOW_THIRD_AD) === 'true'
+
+/**
  * Return an object of ad units we should display. This returns ad units
  * even if ads are disabled.
  * @return {Object} AdUnitsInfo
@@ -152,6 +163,8 @@ export const getAdUnits = () => {
     numberOfAdsToShow = 0
   } else if (shouldShowOneAd()) {
     numberOfAdsToShow = 1
+  } else if (shouldShowThreeAds()) {
+    numberOfAdsToShow = 3
   } else {
     numberOfAdsToShow = DEFAULT_NUMBER_OF_ADS
   }

--- a/src/utils/experiments.js
+++ b/src/utils/experiments.js
@@ -2,3 +2,4 @@ export const MONEY_RAISED_EXCLAMATION_POINT = 'money-raised-exclamation-point'
 export const MONEY_RAISED_EXCLAMATION_POINT_V2 =
   'money-raised-exclamation-point-v2'
 export const YAHOO_SEARCH_NEW_USERS_V2 = 'yahoo-search-new-users-v2'
+export const V4_SHOW_THIRD_AD = 'v4-show-third-ad'


### PR DESCRIPTION
Should merge this first: https://github.com/gladly-team/tab/pull/1370

Also there is a bug where in `tab-web` we pass joined as a Date String in the `setAttributes` call, whereas on the DB side we pass `joined` as a unix epoch timestamp. I don't think it's bitten us too much in the past since we usually on feature values passed to us from the back end anyways, but it *might* explain some weirdness we've seen in setting up `tab-web` tests. This PR fixes that as well.