### PR TITLE
TFAC-1105 Wiring up Celebration Component for GroupImpact

### DIFF
--- a/src/components/groupImpactComponents/GroupImpact.js
+++ b/src/components/groupImpactComponents/GroupImpact.js
@@ -1,19 +1,43 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import GroupImpactSidebar from 'src/components/groupImpactComponents/GroupImpactSidebar'
+import localstorageGroupImpactManager from 'src/utils/localstorageGroupImpactManager'
+import localstorageManager from 'src/utils/localstorage-mgr'
+import { COMPLETED_GROUP_IMPACT_VIEWS } from 'src/utils/constants'
+import Celebration from '../Confetti'
 
-const GroupImpact = ({ groupImpactMetric }) => (
-  <div>
-    <GroupImpactSidebar
-      badgeText=""
-      groupImpactMetric={groupImpactMetric}
-      open={false}
-    />
-  </div>
-)
+const GroupImpact = ({ groupImpactMetric }) => {
+  const lastGroupImpactMetric =
+    localstorageGroupImpactManager.getLastSeenGroupImpactMetric()
+  let displayCelebration = false
+
+  if (
+    lastGroupImpactMetric &&
+    lastGroupImpactMetric.id !== groupImpactMetric.id
+  ) {
+    const views =
+      parseInt(localstorageManager.getItem(COMPLETED_GROUP_IMPACT_VIEWS), 10) ||
+      0
+    if (views === 0) {
+      displayCelebration = true
+    }
+  }
+
+  return (
+    <div>
+      {displayCelebration && <Celebration />}
+      <GroupImpactSidebar
+        badgeText=""
+        groupImpactMetric={groupImpactMetric}
+        open={false}
+      />
+    </div>
+  )
+}
 
 GroupImpact.propTypes = {
   groupImpactMetric: PropTypes.shape({
+    id: PropTypes.string.isRequired,
     dollarProgress: PropTypes.number.isRequired,
     dollarGoal: PropTypes.number.isRequired,
     impactMetric: PropTypes.shape({

--- a/src/components/groupImpactComponents/GroupImpact.stories.jsx
+++ b/src/components/groupImpactComponents/GroupImpact.stories.jsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import blue from '@material-ui/core/colors/blue'
+import localstorageGroupImpactManager from 'src/utils/localstorageGroupImpactManager'
+import localstorageManager from 'src/utils/localstorage-mgr'
+import { COMPLETED_GROUP_IMPACT_VIEWS } from 'src/utils/constants'
 import GroupImpact from './GroupImpact'
 
 export default {
@@ -28,6 +31,7 @@ const Template = (args) => {
 export const open = Template.bind({})
 open.args = {
   groupImpactMetric: {
+    id: 'abcd',
     dollarProgress: 28e5,
     dollarGoal: 5e6,
     impactMetric: {
@@ -37,3 +41,38 @@ open.args = {
     },
   },
 }
+
+export const celebration = Template.bind({})
+celebration.args = {
+  groupImpactMetric: {
+    id: 'abcd',
+    dollarProgress: 28e5,
+    dollarGoal: 5e6,
+    impactMetric: {
+      impactTitle: 'Provide 1 home visit from a community health worker',
+      whyValuableDescription:
+        'Community health workers provide quality health care to those who might not otherwise have access.',
+    },
+  },
+}
+celebration.parameters = {
+  chromatic: {
+    disableSnapshot: true,
+  },
+}
+celebration.decorators = [
+  (Story) => {
+    localstorageManager.setItem(COMPLETED_GROUP_IMPACT_VIEWS, 0)
+    localstorageGroupImpactManager.setLastSeenGroupImpactMetric({
+      id: 'bcde',
+      dollarProgress: 28e5,
+      dollarGoal: 5e6,
+      impactMetric: {
+        impactTitle: 'Provide 1 home visit from a community health worker',
+        whyValuableDescription:
+          'Community health workers provide quality health care to those who might not otherwise have access.',
+      },
+    })
+    return <Story />
+  },
+]

--- a/src/components/groupImpactComponents/GroupImpactContainer.js
+++ b/src/components/groupImpactComponents/GroupImpactContainer.js
@@ -5,6 +5,7 @@ export default createFragmentContainer(GroupImpact, {
   user: graphql`
     fragment GroupImpactContainer_cause on Cause {
       groupImpactMetric {
+        id
         dollarProgress
         dollarGoal
         impactMetric {

--- a/src/components/groupImpactComponents/__tests__/GroupImpact.test.js
+++ b/src/components/groupImpactComponents/__tests__/GroupImpact.test.js
@@ -1,8 +1,15 @@
 import React from 'react'
 import { shallow } from 'enzyme'
+import localstorageGroupImpactManager from 'src/utils/localstorageGroupImpactManager'
+import localstorageManager from 'src/utils/localstorage-mgr'
+import Celebration from 'src/components/Confetti'
+
+jest.mock('src/utils/localstorage-mgr')
+jest.mock('src/utils/localstorageGroupImpactManager')
 
 const getMockProps = () => ({
   groupImpactMetric: {
+    id: 'abcd',
     dollarProgress: 250,
     dollarGoal: 600,
     impactMetric: {
@@ -20,5 +27,68 @@ describe('GroupImpact component', () => {
     expect(() => {
       shallow(<GroupImpact {...mockProps} />)
     }).not.toThrow()
+  })
+
+  it('renders celebration if there is a different last group impact metric and viewed once', () => {
+    const GroupImpact =
+      require('src/components/groupImpactComponents/GroupImpact').default
+    const mockProps = getMockProps()
+    localstorageManager.getItem.mockReturnValue('0')
+    localstorageGroupImpactManager.getLastSeenGroupImpactMetric.mockReturnValue(
+      {
+        id: 'bcde',
+        dollarProgress: 28e5,
+        dollarGoal: 5e6,
+        impactMetric: {
+          impactTitle: 'Provide 1 home visit from a community health worker',
+          whyValuableDescription:
+            'Community health workers provide quality health care to those who might not otherwise have access.',
+        },
+      }
+    )
+    const wrapper = shallow(<GroupImpact {...mockProps} />)
+    expect(wrapper.find(Celebration).length).toEqual(1)
+  })
+
+  it('does not render celebration if new goal views > 0', () => {
+    const GroupImpact =
+      require('src/components/groupImpactComponents/GroupImpact').default
+    const mockProps = getMockProps()
+    localstorageManager.getItem.mockReturnValue('1')
+    localstorageGroupImpactManager.getLastSeenGroupImpactMetric.mockReturnValue(
+      {
+        id: 'bcde',
+        dollarProgress: 28e5,
+        dollarGoal: 5e6,
+        impactMetric: {
+          impactTitle: 'Provide 1 home visit from a community health worker',
+          whyValuableDescription:
+            'Community health workers provide quality health care to those who might not otherwise have access.',
+        },
+      }
+    )
+    const wrapper = shallow(<GroupImpact {...mockProps} />)
+    expect(wrapper.find(Celebration).length).toEqual(0)
+  })
+
+  it('does not render celebration same group impact metric', () => {
+    const GroupImpact =
+      require('src/components/groupImpactComponents/GroupImpact').default
+    const mockProps = getMockProps()
+    localstorageManager.getItem.mockReturnValue('0')
+    localstorageGroupImpactManager.getLastSeenGroupImpactMetric.mockReturnValue(
+      {
+        id: 'abcd',
+        dollarProgress: 28e5,
+        dollarGoal: 5e6,
+        impactMetric: {
+          impactTitle: 'Provide 1 home visit from a community health worker',
+          whyValuableDescription:
+            'Community health workers provide quality health care to those who might not otherwise have access.',
+        },
+      }
+    )
+    const wrapper = shallow(<GroupImpact {...mockProps} />)
+    expect(wrapper.find(Celebration).length).toEqual(0)
   })
 })


### PR DESCRIPTION
The rule here is: first view on a new group impact metric. The rest of the wiring (incrementing the view count correctly, setting the last group impact value) will continue in TFAC-1104.

https://gladlyteam.atlassian.net/jira/software/projects/TFAC/boards/1?selectedIssue=TFAC-1004