### PR TITLE
[TFAC-1023]: Test out a stronger "supporting" statement on the new tab page

### DIFF
--- a/src/__tests__/pages/index.test.js
+++ b/src/__tests__/pages/index.test.js
@@ -151,6 +151,7 @@ const getMockProps = () => ({
         landingPagePath: '/foo/',
         impactType: CAUSE_IMPACT_TYPES.individual,
         name: 'Example Cause',
+        landingPagePhrase: 'Landing Phase Example Cause',
         onboarding: {
           steps: [],
         },
@@ -1474,7 +1475,7 @@ describe('index.js', () => {
     useData.mockReturnValue({ data: mockProps.data })
     const wrapper = mount(<IndexPage {...mockProps} />)
     const elem = wrapper.find(Chip)
-    expect(elem.prop('label')).toEqual('Supporting: Example Cause')
+    expect(elem.prop('label')).toEqual('Landing Phase Example Cause')
     elem.simulate('click')
     expect(goTo).toHaveBeenCalledWith(aboutURL)
   })

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -362,6 +362,7 @@ const getRelayQuery = async ({ AuthUser }) => {
             impactType
             impactVisits
             landingPagePath
+            landingPagePhrase
             name
             onboarding {
               steps {
@@ -453,13 +454,8 @@ const Index = ({ data: fallbackData, userAgent }) => {
     searches,
     showSfacIcon,
   } = user || {}
-  const {
-    theme,
-    onboarding,
-    causeId,
-    impactType,
-    name: causeName,
-  } = cause || {}
+  const { theme, onboarding, causeId, impactType, landingPagePhrase } =
+    cause || {}
   const { primaryColor, secondaryColor } = theme || {}
 
   const growthbook = useGrowthBook()
@@ -971,7 +967,7 @@ const Index = ({ data: fallbackData, userAgent }) => {
                 className={classes.logo}
               />
               <Chip
-                label={`Supporting: ${causeName}`}
+                label={landingPagePhrase}
                 className={classes.supportingChip}
                 color="primary"
                 size="small"
@@ -1055,6 +1051,7 @@ Index.propTypes = {
         impactType: PropTypes.string.isRequired,
         impactVisits: PropTypes.number,
         landingPagePath: PropTypes.string,
+        landingPagePhrase: PropTypes.string,
         name: PropTypes.string.isRequired,
         theme: PropTypes.shape({
           primaryColor: PropTypes.string.isRequired,

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -293,6 +293,9 @@ type Cause implements Node {
   """URL path for the landing page belonging to this cause"""
   landingPagePath: String!
 
+  """Phrase for the landing page belonging to this cause"""
+  landingPagePhrase: String!
+
   """Whether or not the current cause supports individual impact"""
   individualImpactEnabled: Boolean! @deprecated(reason: "Replaced by \"impactType\" field.")
 


### PR DESCRIPTION
This PR changes a few props around and updates the UI to use the `landingPagePhrase` variable from graphql to update the supporting phrase. 

Updated unit test as well.