### PR TITLE
Chromatic requires v16, so Fixing That

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,6 +4,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}


### PR DESCRIPTION
Failing because the workflow is failing due to it using node v18 for whatever reason. This fixes that.