### PR TITLE
Small GroupImpact Sidebar Changes

### DIFF
--- a/src/components/groupImpactComponents/GroupImpactSidebar.js
+++ b/src/components/groupImpactComponents/GroupImpactSidebar.js
@@ -82,8 +82,8 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'center',
   },
   divider: {
-    marginTop: theme.spacing(3),
-    marginBottom: theme.spacing(3),
+    marginTop: theme.spacing(1.5),
+    marginBottom: theme.spacing(1.5),
   },
   buttonContent: {
     display: 'flex',
@@ -339,8 +339,8 @@ const GroupImpactSidebar = ({
             tooltips={[
               `${
                 totalProgress - searchDollarProgress
-              }% of funds was raised by tabs opened through Tab for a Cause`,
-              `${searchDollarProgress}% of funds was raised by searches through Search for a Cause`,
+              }% of funds raised by tabs opened through Tab for a Cause`,
+              `${searchDollarProgress}% of funds raised by searches through Search for a Cause`,
             ]}
           />
           <Fade in={displaySidebarText} timeout={500}>
@@ -475,7 +475,7 @@ const GroupImpactSidebar = ({
             defaultTheme.palette.colors.tab,
             defaultTheme.palette.colors.search,
           ]}
-          width={isClosedHover ? 24 : 8}
+          width={isClosedHover ? 24 : 16}
           borderRadius={0}
           showMarkers={false}
         />

--- a/src/components/groupImpactComponents/__tests__/GroupImpactSidebar.test.js
+++ b/src/components/groupImpactComponents/__tests__/GroupImpactSidebar.test.js
@@ -153,8 +153,8 @@ describe('GroupImpactSidebar component', () => {
     expect(
       wrapper.find(VerticalLinearProgress).first().prop('tooltips')
     ).toEqual([
-      `25% of funds was raised by tabs opened through Tab for a Cause`,
-      `16% of funds was raised by searches through Search for a Cause`,
+      `25% of funds raised by tabs opened through Tab for a Cause`,
+      `16% of funds raised by searches through Search for a Cause`,
     ])
     expect(wrapper.find(VerticalLinearProgress).at(1).prop('progress')).toEqual(
       [
@@ -205,8 +205,8 @@ describe('GroupImpactSidebar component', () => {
     expect(
       wrapper.find(VerticalLinearProgress).first().prop('tooltips')
     ).toEqual([
-      `2% of funds was raised by tabs opened through Tab for a Cause`,
-      `1% of funds was raised by searches through Search for a Cause`,
+      `2% of funds raised by tabs opened through Tab for a Cause`,
+      `1% of funds raised by searches through Search for a Cause`,
     ])
     expect(wrapper.find(VerticalLinearProgress).at(1).prop('progress')).toEqual(
       [3, 1]
@@ -253,7 +253,7 @@ describe('GroupImpactSidebar component', () => {
     }
     const wrapper = shallow(<GroupImpactSidebar {...mockProps} />)
 
-    expect(wrapper.find(VerticalLinearProgress).at(1).prop('width')).toEqual(8)
+    expect(wrapper.find(VerticalLinearProgress).at(1).prop('width')).toEqual(16)
 
     wrapper.find(Box).at(1).simulate('mouseover')
     wrapper.update()


### PR DESCRIPTION
- Small copy change (remove 'was' from tooltips)
- Made width of non-extended impact sidebar larger
- Reduced some spacing to give sidebar more room for other content