### PR TITLE
First round of Feedback for Bookmarks

### DIFF
--- a/src/components/AddShortcut.js
+++ b/src/components/AddShortcut.js
@@ -63,14 +63,15 @@ const AddShortcut = ({
   useEffect(() => setUrl(existingUrl), [existingUrl])
   const classes = useStyles()
   const onCancelClick = () => {
-    setName('')
-    setUrl('')
+    setName(existingName)
+    setUrl(existingUrl)
     onCancel()
   }
   const onSaveClick = () => {
-    onSave(existingId, name, addProtocolToURLIfNeeded(url))
-    setName('')
-    setUrl('')
+    const newUrl = addProtocolToURLIfNeeded(url)
+    onSave(existingId, name, newUrl)
+    setName(name)
+    setUrl(newUrl)
   }
   const changeName = (e) => {
     setName(e.target.value)
@@ -88,7 +89,8 @@ const AddShortcut = ({
             gutterBottom
             color="primary"
           >
-            Add Shortcut
+            {existingName === '' && existingUrl === '' ? 'Add' : 'Edit'}{' '}
+            Shortcut
           </Typography>
           <hr />
           <div className={classes.urlFields}>

--- a/src/components/FrontpageShortcutList.js
+++ b/src/components/FrontpageShortcutList.js
@@ -34,6 +34,8 @@ const useStyles = makeStyles((theme) => ({
   shortcutList: {
     display: 'flex',
     flexDirection: 'row',
+    maxWidth: '550px',
+    flexWrap: 'wrap',
   },
   addCircle: {
     marginTop: '24px',
@@ -144,7 +146,7 @@ const FrontpageShortcutList = ({ openHandler, user }) => {
 
   const classes = useStyles()
   const shortcutIcons = bookmarks
-    .slice(-4)
+    .slice(-9)
     .map((bookmark) => (
       <ShortcutIcon
         key={bookmark.id}

--- a/src/components/FrontpageShortcutList.stories.jsx
+++ b/src/components/FrontpageShortcutList.stories.jsx
@@ -28,6 +28,7 @@ const Template = (args) => {
 }
 export const standard = Template.bind({})
 standard.args = {
+  userId: 'userId',
   user: {
     widgets: {
       edges: [
@@ -68,6 +69,31 @@ standard.args = {
                 },
                 {
                   id: 'ghij',
+                  name: 'google4',
+                  link: 'https://www.google2.com',
+                },
+                {
+                  id: 'hijk',
+                  name: 'google2',
+                  link: 'https://www.google2.com',
+                },
+                {
+                  id: 'ijkl',
+                  name: 'espn2',
+                  link: 'https://www.espn2.com',
+                },
+                {
+                  id: 'jklm',
+                  name: 'google3',
+                  link: 'https://www.google.com',
+                },
+                {
+                  id: 'klmn',
+                  name: 'espn3',
+                  link: 'https://www.espn.com',
+                },
+                {
+                  id: 'lmno',
                   name: 'google4',
                   link: 'https://www.google2.com',
                 },

--- a/src/components/ShortcutIcon.js
+++ b/src/components/ShortcutIcon.js
@@ -9,17 +9,15 @@ import IconButton from '@material-ui/core/IconButton'
 import Fade from '@material-ui/core/Fade'
 import DeleteIcon from '@material-ui/icons/Delete'
 import EditIcon from '@material-ui/icons/Edit'
+import CheckIcon from '@material-ui/icons/Check'
 import Link from 'src/components/Link'
+import CloseIcon from '@material-ui/icons/Close'
 
 const useStyles = makeStyles((theme) => ({
   button: {
     height: '150px',
     width: '110px',
     maxWidth: '110px',
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignItems: 'center',
     borderRadius: '10px',
     padding: theme.spacing(1),
   },
@@ -39,6 +37,7 @@ const useStyles = makeStyles((theme) => ({
     '&:hover': {
       color: 'white',
     },
+    color: '#cccccc',
   },
   letterIcon: {
     width: '70px',
@@ -61,6 +60,25 @@ const useStyles = makeStyles((theme) => ({
     paddingRight: theme.spacing(1),
     color: 'white',
   },
+  link: {
+    height: '100%',
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  deleteText: {
+    color: 'white',
+    textAlign: 'center',
+  },
+  confirmDialog: {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
 }))
 const ShortcutIcon = ({ onEdit, onDelete, text, url, id }) => {
   const getFirstTwoLetters = (str) => {
@@ -69,10 +87,19 @@ const ShortcutIcon = ({ onEdit, onDelete, text, url, id }) => {
     return firstLetters.slice(0, 2).join('')
   }
   const [hover, setHover] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
   const classes = useStyles()
   const firstLettersText = getFirstTwoLetters(text)
-  const onDeleteHandler = (event) => {
+  const onDeleteConfirmHandler = (event) => {
     onDelete(id)
+    event.preventDefault()
+  }
+  const onDeleteRejectHandler = (event) => {
+    setConfirmDelete(false)
+    event.preventDefault()
+  }
+  const onDeleteHandler = (event) => {
+    setConfirmDelete(true)
     event.preventDefault()
   }
   const onEditHandler = (event) => {
@@ -80,31 +107,54 @@ const ShortcutIcon = ({ onEdit, onDelete, text, url, id }) => {
     event.preventDefault()
   }
   return (
-    <Link to={url} target="_blank">
-      <div
-        className={hover ? clsx(classes.button, classes.hover) : classes.button}
-        onMouseOver={() => setHover(true)}
-        onMouseOut={() => setHover(false)}
-      >
-        <Fade in={hover}>
+    <div
+      className={hover ? clsx(classes.button, classes.hover) : classes.button}
+      onMouseOver={() => setHover(true)}
+      onMouseOut={() => setHover(false)}
+    >
+      {confirmDelete ? (
+        <div className={classes.confirmDialog}>
           <div className={classes.buttons}>
             <IconButton
               className={classes.miniButton}
-              onClick={onDeleteHandler}
+              onClick={onDeleteConfirmHandler}
             >
-              <DeleteIcon />
+              <CheckIcon />
             </IconButton>
-            <IconButton className={classes.miniButton} onClick={onEditHandler}>
-              <EditIcon />
+            <IconButton
+              className={classes.miniButton}
+              onClick={onDeleteRejectHandler}
+            >
+              <CloseIcon />
             </IconButton>
           </div>
-        </Fade>
-        <div className={classes.letterIcon}>
-          <Typography variant="h6">{firstLettersText}</Typography>
+          <Typography className={classes.deleteText}>Confirm Delete</Typography>
         </div>
-        <Typography className={classes.overflow}>{text}</Typography>
-      </div>
-    </Link>
+      ) : (
+        <Link to={url} target="_blank" className={classes.link}>
+          <Fade in={hover}>
+            <div className={classes.buttons}>
+              <IconButton
+                className={classes.miniButton}
+                onClick={onDeleteHandler}
+              >
+                <DeleteIcon />
+              </IconButton>
+              <IconButton
+                className={classes.miniButton}
+                onClick={onEditHandler}
+              >
+                <EditIcon />
+              </IconButton>
+            </div>
+          </Fade>
+          <div className={classes.letterIcon}>
+            <Typography variant="h6">{firstLettersText}</Typography>
+          </div>
+          <Typography className={classes.overflow}>{text}</Typography>
+        </Link>
+      )}
+    </div>
   )
 }
 

--- a/src/components/ShortcutIcon.stories.jsx
+++ b/src/components/ShortcutIcon.stories.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from 'react'
 import ShortcutIcon from './ShortcutIcon'
 
@@ -22,4 +23,6 @@ basic.args = {
   id: 'abcd',
   text: 'Google Googledy',
   url: 'https://www.google.com',
+  onEdit: () => console.log('onEdit'),
+  onDelete: () => console.log('onDelete'),
 }

--- a/src/components/__tests__/AddShortcutPage.test.js
+++ b/src/components/__tests__/AddShortcutPage.test.js
@@ -303,6 +303,9 @@ describe('AddShortcutPage component', () => {
     wrapper.find(ShortcutIcon).at(0).find(IconButton).at(0).simulate('click')
     wrapper.update()
 
+    wrapper.find(ShortcutIcon).at(0).find(IconButton).at(0).simulate('click')
+    wrapper.update()
+
     await flushAllPromises()
     expect(UpdateWidgetDataMutation).toHaveBeenCalledWith(
       mockProps.user,

--- a/src/components/__tests__/FrontpageShortcutList.test.js
+++ b/src/components/__tests__/FrontpageShortcutList.test.js
@@ -55,6 +55,31 @@ const getMockBookmarks = () => [
     name: 'google4',
     link: 'https://www.google2.com',
   },
+  {
+    id: 'hijk',
+    name: 'google2',
+    link: 'https://www.google2.com',
+  },
+  {
+    id: 'ijkl',
+    name: 'espn2',
+    link: 'https://www.espn2.com',
+  },
+  {
+    id: 'jklm',
+    name: 'google3',
+    link: 'https://www.google.com',
+  },
+  {
+    id: 'klmn',
+    name: 'espn3',
+    link: 'https://www.espn.com',
+  },
+  {
+    id: 'lmno',
+    name: 'google4',
+    link: 'https://www.google2.com',
+  },
 ]
 const getMockProps = () => ({
   userId: 'userId',
@@ -86,7 +111,7 @@ describe('FrontpageShortcutList component', () => {
     }).not.toThrow()
   })
 
-  it('displays up to four icons for links', () => {
+  it('displays up to nine icons for links', () => {
     const FrontpageShortcutList =
       require('src/components/FrontpageShortcutList').default
     const mockProps = getMockProps()
@@ -95,8 +120,8 @@ describe('FrontpageShortcutList component', () => {
 
     const shortcutIcons = wrapper.find(ShortcutIcon)
 
-    expect(shortcutIcons.length).toEqual(4)
-    for (let i = 0; i < 4; i += 1) {
+    expect(shortcutIcons.length).toEqual(9)
+    for (let i = 0; i < 9; i += 1) {
       const shortcutIcon = shortcutIcons.at(i)
       expect(shortcutIcon.prop('text')).toEqual(bookmarks[i + 3].name)
       expect(shortcutIcon.prop('url')).toEqual(bookmarks[i + 3].link)
@@ -191,7 +216,7 @@ describe('FrontpageShortcutList component', () => {
       })
     )
     wrapper.update()
-    expect(wrapper.find(ShortcutIcon).length).toEqual(4)
+    expect(wrapper.find(ShortcutIcon).length).toEqual(9)
     expect(wrapper.find(Backdrop).first().prop('open')).toBe(false)
   })
 
@@ -230,16 +255,19 @@ describe('FrontpageShortcutList component', () => {
       })
     )
     wrapper.update()
-    expect(wrapper.find(ShortcutIcon).length).toEqual(4)
+    expect(wrapper.find(ShortcutIcon).length).toEqual(9)
     expect(wrapper.find(Backdrop).first().prop('open')).toBe(false)
   })
 
-  it('delete bookmark flow works', async () => {
+  it('delete bookmark flow works if confirmed', async () => {
     const FrontpageShortcutList =
       require('src/components/FrontpageShortcutList').default
     const mockProps = getMockProps()
     const wrapper = mount(<FrontpageShortcutList {...mockProps} />)
     const mockBookmarks = getMockBookmarks()
+
+    wrapper.find(ShortcutIcon).at(0).find(IconButton).at(0).simulate('click')
+    wrapper.update()
 
     wrapper.find(ShortcutIcon).at(0).find(IconButton).at(0).simulate('click')
     wrapper.update()
@@ -255,7 +283,7 @@ describe('FrontpageShortcutList component', () => {
     )
 
     wrapper.update()
-    expect(wrapper.find(ShortcutIcon).length).toEqual(4)
+    expect(wrapper.find(ShortcutIcon).length).toEqual(9)
     expect(wrapper.find(Backdrop).first().prop('open')).toBe(false)
   })
 

--- a/src/components/__tests__/ShortcutIcon.test.js
+++ b/src/components/__tests__/ShortcutIcon.test.js
@@ -49,15 +49,12 @@ describe('ShortcutIcon component', () => {
     expect(wrapper.find(Fade).prop('in')).toEqual(true)
   })
 
-  it('calls edit and delete button on clicks', () => {
+  it('calls edit handler on clicks', () => {
     const ShortcutIcon = require('src/components/ShortcutIcon').default
     const mockProps = getMockProps()
     const wrapper = mount(<ShortcutIcon {...mockProps} />)
 
     wrapper.find(Fade).simulate('mouseover')
-
-    wrapper.find(IconButton).first().simulate('click')
-    expect(mockProps.onDelete).toHaveBeenCalledWith(mockProps.id)
 
     wrapper.find(IconButton).at(1).simulate('click')
     expect(mockProps.onEdit).toHaveBeenCalledWith(
@@ -65,6 +62,30 @@ describe('ShortcutIcon component', () => {
       mockProps.text,
       mockProps.url
     )
+  })
+
+  it('calls delete handler on confirmation', () => {
+    const ShortcutIcon = require('src/components/ShortcutIcon').default
+    const mockProps = getMockProps()
+    const wrapper = mount(<ShortcutIcon {...mockProps} />)
+
+    wrapper.find(Fade).simulate('mouseover')
+
+    wrapper.find(IconButton).first().simulate('click')
+    wrapper.find(IconButton).first().simulate('click')
+    expect(mockProps.onDelete).toHaveBeenCalledWith(mockProps.id)
+  })
+
+  it('does delete handler on unconfirmed', () => {
+    const ShortcutIcon = require('src/components/ShortcutIcon').default
+    const mockProps = getMockProps()
+    const wrapper = mount(<ShortcutIcon {...mockProps} />)
+
+    wrapper.find(Fade).simulate('mouseover')
+
+    wrapper.find(IconButton).first().simulate('click')
+    wrapper.find(IconButton).at(1).simulate('click')
+    expect(mockProps.onDelete).not.toHaveBeenCalledWith()
   })
 
   it('default handlers do not throw', () => {
@@ -77,11 +98,11 @@ describe('ShortcutIcon component', () => {
     wrapper.find(Fade).simulate('mouseover')
 
     expect(() => {
-      wrapper.find(IconButton).first().simulate('click')
+      wrapper.prop('onEdit')()
     }).not.toThrow()
 
     expect(() => {
-      wrapper.find(IconButton).at(1).simulate('click')
+      wrapper.prop('onDelete')()
     }).not.toThrow()
   })
 })

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -256,7 +256,7 @@ const useStyles = makeStyles((theme) => ({
     margin: theme.spacing(1),
   },
   frontpageShortcutList: {
-    zIndex: 1e4,
+    zIndex: 1.4e3,
   },
   logo: {
     height: 50,
@@ -984,8 +984,8 @@ const Index = ({ data: fallbackData, userAgent }) => {
                 <div className={classes.timelineBar} />
               </Link>
             ) : null}
-            {localStorageFeaturesManager.getFeatureValue(LAUNCH_BOOKMARKS) !==
-              'false' &&
+            {localStorageFeaturesManager.getFeatureValue(LAUNCH_BOOKMARKS) ===
+              'true' &&
               bookmarkWidgetEnabled && (
                 <Modal open={addShortcutPageOpen}>
                   <Box>


### PR DESCRIPTION
Covered in this PR: 

* Make the ShortcutIcon hover buttons lighter
* Change “Add Shortcut” to “Edit Shortcut” if applicable
* Make sure Edit Shortcut menu properly pre-populates the text
* Have up to two rows of icons (9 shortcuts). Test smaller screen sizes with this and scale down if appropriate
* Confirm the delete interaction on the Shortcut Icon 
* Make the shortcut icons display behind ads on super small screens (or remove?)
