### PR TITLE
Stop setting the redundant TabAuthToken cookie

### DIFF
--- a/src/utils/auth/__tests__/initAuth.test.js
+++ b/src/utils/auth/__tests__/initAuth.test.js
@@ -6,6 +6,7 @@ import { CUSTOM_HEADER_NAME } from 'src/utils/middleware/constants'
 
 jest.mock('next-firebase-auth')
 jest.mock('src/utils/logger')
+jest.mock('cookies-next')
 
 beforeEach(() => {
   process.env.COOKIE_SECURE_SAME_SITE_NONE = 'true'
@@ -56,6 +57,29 @@ describe('initAuth.js', () => {
     initAuth()
     const config = initNFA.mock.calls[0][0]
     expect(config).toHaveProperty('tokenChangedHandler')
+  })
+
+  test('tokenChangedHandler deletes the legacy TabAuthToken cookie on every invocation', async () => {
+    // v5 used to read TabAuthToken (a duplicate of the Firebase ID token
+    // that we set client-side). v5 now reads TabAuth.AuthUserTokens directly,
+    // so we delete the legacy cookie to free up request-header space.
+    expect.assertions(2)
+    const { init: initNFA } = require('next-firebase-auth')
+    const { deleteCookie } = require('cookies-next')
+    const initAuth = require('src/utils/auth/initAuth').default
+    initAuth()
+    fetch.mockResolvedValue(getMockFetchResponse())
+    const config = initNFA.mock.calls[0][0]
+
+    // Authed branch
+    await config.tokenChangedHandler(getMockAuthUser())
+    expect(deleteCookie).toHaveBeenCalledWith('TabAuthToken', { path: '/' })
+
+    deleteCookie.mockClear()
+
+    // Unauthed branch
+    await config.tokenChangedHandler({})
+    expect(deleteCookie).toHaveBeenCalledWith('TabAuthToken', { path: '/' })
   })
 
   test('tokenChangedHandler calls login endpoint and sets custom header', async () => {

--- a/src/utils/auth/initAuth.js
+++ b/src/utils/auth/initAuth.js
@@ -3,7 +3,7 @@ import ensureValuesAreDefined from 'src/utils/ensureValuesAreDefined'
 import { apiLogin, apiLogout, authURL, dashboardURL } from 'src/utils/urls'
 import { CUSTOM_HEADER_NAME } from 'src/utils/middleware/constants'
 import logger from 'src/utils/logger'
-import { setCookie } from 'cookies-next'
+import { deleteCookie } from 'cookies-next'
 
 try {
   ensureValuesAreDefined([
@@ -24,15 +24,18 @@ const useSecureSameSiteNone =
 const tokenChangedHandler = async (authUser) => {
   let response
 
+  // Delete the legacy TabAuthToken cookie that was previously set client-side
+  // for v5's benefit. v5 now reads the Firebase ID token directly from the
+  // dotted TabAuth.AuthUserTokens cookie that next-firebase-auth manages
+  // server-side via apiLogin, so the duplicate cookie is no longer needed.
+  // The cookie was originally set with a 1-year expiry, so we explicitly
+  // delete it on every tokenChangedHandler invocation to clear it from
+  // existing browsers.
+  deleteCookie('TabAuthToken', { path: '/' })
+
   // If the user is authed, call login to set a cookie.
   if (authUser.id) {
     const userToken = await authUser.getIdToken()
-
-    // This is used by v5 of our app as cloudfront does not support cookies with dots in them.
-    const currentDate = new Date()
-    const nextYearDate = new Date(currentDate)
-    nextYearDate.setFullYear(currentDate.getFullYear() + 1)
-    setCookie('TabAuthToken', userToken, { expires: nextYearDate })
 
     response = await fetch(apiLogin, {
       method: 'POST',


### PR DESCRIPTION
## Summary
Stops setting `TabAuthToken` in `tokenChangedHandler` and explicitly deletes any pre-existing `TabAuthToken` cookie. This is part 2 of the migration to retire the duplicate Firebase auth cookie that v5 used to read.

## Why

v5 used to read `TabAuthToken` — a 1-2 KB duplicate of the Firebase ID token that we wrote client-side via `document.cookie` for v5's benefit. As of [tab-v5#150](https://github.com/gladly-team/tab-v5/pull/150), v5 reads the same idToken directly from the dotted `TabAuth.AuthUserTokens` cookie that `next-firebase-auth` already manages server-side via `apiLogin`. With both reads done from the same source, the client-side duplicate is dead weight.

## Why this matters

CloudFront access logs show ~3.7% of users are within 3 KB of CloudFront's 32 KB request-size limit and ~8% are over it (most CloudFront edges seem lenient, but the strict ones return 494 errors that users have been reporting). Removing this 1-2 KB cookie pulls borderline users out of 494 territory.

## Changes
- Replaced `setCookie('TabAuthToken', ...)` call with `deleteCookie('TabAuthToken', { path: '/' })` so existing browsers actively clear the cookie on the next `tokenChangedHandler` invocation (rather than leaving it to expire over up to 1 year).
- Removed the now-unused `nextYearDate` calculation.
- Removed the misleading comment about CloudFront not supporting dotted cookies — verified empirically that CloudFront forwards dotted cookies fine when whitelisted in the origin request policy. The original obstacle was actually PHP's `\$_COOKIE` rewriting dots to underscores, which v5 now bypasses by reading `\$_SERVER['HTTP_COOKIE']` directly.
- Added test asserting `deleteCookie` is called in both authed and unauthed branches.

## v5 fallback safety

[tab-v5#150](https://github.com/gladly-team/tab-v5/pull/150) deployed with a fallback: if `TabAuth.AuthUserTokens` isn't readable for any reason, v5 falls back to `TabAuthToken`. Production logs show the new cookie is being read successfully for active v4 users (the population that actually loads tab-web). For users who don't load tab-web (Chrome extension API calls, v1 users) the fallback continues to apply — they still have whatever stale `TabAuthToken` they had previously, and this PR's deletion only fires when a user *does* load tab-web.

## Test plan
- [ ] Deploy
- [ ] Hard-refresh tab.gladly.io in a logged-in browser, verify in DevTools that `TabAuthToken` is gone from the cookie list while `TabAuth.AuthUserTokens` remains
- [ ] Verify v5 routes still work (open new tab → notifications iframe loads, search redirects work, /v5/* pages render)
- [ ] In Better Stack, watch for any spike in `Auth: fell back to TabAuthToken` from `/v5/*` paths (most fallback should remain on `/api/v1/tab/log` from extension calls — that's expected and fine)

## Follow-up (not in this PR)
- Small cleanup PR in tab-v5 to drop the 5 Blade templates that also set/clear `TabAuthToken` via `document.cookie` — those are legacy and now duplicative.
- Eventually: remove the `TabAuthToken` fallback path in v5 and drop the cookie from CloudFront's `v5-request-policy` whitelist after confirming the fallback rate is at zero or near-zero.